### PR TITLE
0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ yarn-debug.log*
 yarn-error.log*
 .npm
 .yarn-integrity
+test

--- a/README.md
+++ b/README.md
@@ -27,66 +27,94 @@ Then just require it as a plugin.
 ```js
 // tailwind.config.js
 module.exports = {
-  plugins: [
-    require('tailwindcss-neumorphism')
-  ]
+  plugins: [require('tailwindcss-neumorphism')],
 }
 ```
 
-The plugin will generate 4 different utilities per color.
+The plugin will generate 4 different utilities per color, in any number of sizes (default 5).
 
 ```css
 .nm-flat-red-500 {
-  background: #D8391E;
-  box-shadow: 0.15em 0.15em 0.3em #A22B17, -0.15em -0.15em 0.3em #E6634D;
-}
-
-.nm-convex-red-500 {
-  background: linear-gradient(145deg, #B8301A, #E03E22);
-  box-shadow: 0.15em 0.15em 0.3em #A22B17, -0.15em -0.15em 0.3em #E6634D;
+  background: #F56565;
+  box-shadow: 0.2em 0.2em calc(0.2em * 2) #F01414, calc(0.2em * -1) calc(0.2em * -1) calc(0.2em * 2) #F9A6A6;
 }
 
 .nm-concave-red-500 {
-  background: linear-gradient(145deg, #E03E22, #B8301A);
-  box-shadow: 0.15em 0.15em 0.3em #A22B17, -0.15em -0.15em 0.3em #E6634D;
+  background: linear-gradient(145deg, #F23434, #F78585);
+  box-shadow: 0.2em 0.2em calc(0.2em * 2) #F01414, calc(0.2em * -1) calc(0.2em * -1) calc(0.2em * 2) #F9A6A6;
+}
+
+.nm-convex-red-500 {
+  background: linear-gradient(145deg, #F78585, #F23434);
+  box-shadow: 0.2em 0.2em calc(0.2em * 2) #F01414, calc(0.2em * -1) calc(0.2em * -1) calc(0.2em * 2) #F9A6A6;
 }
 
 .nm-inset-red-500 {
-  background: #D8391E;
-  box-shadow: inset 0.15em 0.15em 0.3em #A22B17, inset -0.15em -0.15em 0.3em #E6634D;
+  background: linear-gradient(145deg, #F78585, #F23434);
+  box-shadow: inset 0.2em 0.2em calc(0.2em * 2) #F01414, inset calc(0.2em * -1) calc(0.2em * -1) calc(0.2em * 2) #F9A6A6;
 }
+
+.nm-flat-red-500-lg {
+  background: #F56565;
+  box-shadow: 0.4em 0.4em calc(0.4em * 2) #F01414, calc(0.4em * -1) calc(0.4em * -1) calc(0.4em * 2) #F9A6A6;
+}
+
+/* ... */
 ```
 
 ### Colors
 
-By default, neumorphism classes will be generated for all of your colors. Alternatively, you can set these colors explicitly in the config.
+By default, neumorphism classes will be generated for all of your background colors. Alternatively, you can set these colors explicitly in the config under `neumorphismColor`.
 
 ```js
 module.exports = {
   // ...
   theme: {
-    neumorphism: {
+    neumorphismColor: {
       red: {
         100: '#FBEBE9',
         200: '#F5CEC7',
         // ...
-      }
-    }
-  }
+      },
+    },
+  },
+  // ...
+}
+```
+
+### Sizes
+
+You can change the sizes of the generated neumorphisms using the `neumorphismSize` property. There are 5 sizes by default, ranging from `xs` to `xl`. Setting a key of `default` will generate an unsuffixed class. Values can be generated from any valid sizing unit.
+
+```js
+module.exports = {
+  // ...
+  theme: {
+    neumorphismSize: {
+      xs: '0.05em',
+      sm: '0.1em',
+      default: '0.2em',
+      lg: '0.4em',
+      xl: '0.8em',
+    },
+  },
   // ...
 }
 ```
 
 ### Variants
 
-The default variants for neumorphism utilities are `responsive`, `hover` and `focus`. These can be configured [like any other tailwind utility](https://tailwindcss.com/docs/configuring-variants/).
+The default variants for each neumorphism utility are `responsive`, `hover` and `focus`. These can be configured [like any other tailwind utility](https://tailwindcss.com/docs/configuring-variants/), including being toggled on and off individually.
 
 ```js
 module.exports = {
   // ...
   variants: {
-    neumorphism: ['responsive']
-  }
+    neumorphismFlat: ['responsive'],
+    neumorphismConcave: false,
+    neumorphismConvex: ['responsive', 'hover'],
+    neumorphismInset: ['focus', 'active'],
+  },
   // ...
 }
 ```

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports = plugin(
               ? `.${e(`nm-inset-${colorKey}`)}`
               : `.${e(`nm-inset-${colorKey}-${sizeKey}`)}`,
             {
-              background: `linear-gradient(145deg, ${shades.highlightGradient}, ${shades.shadowGradient})`,
+              background: shades.baseColor,
               boxShadow: `inset ${size} ${size} calc(${size} * 2) ${shades.shadowColor}, inset calc(${size} * -1) calc(${size} * -1) calc(${size} * 2) ${shades.highlightColor}`,
             },
           ])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-neumorphism",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Generate soft UI CSS code using tailwindcss",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
# The *customizability* update

The first major update for tailwindcss-neumorphism is here, and it adds some new useful customizability options.

## What's new?

* Multiple sizes! By default effects are generated from `xs` to `xl` (5 in total) but can be to any number of sizes. Values can be generated from any valid sizing unit (`px`/`em`/`%` etc). Setting a key of `default` will generate an unsuffixed class. 
* The `neumorphism` variant has been split into its separate effects; `neumorphismFlat`, `neumorphismConcave`, `neumorphismConvex`, and `neumorphismInset`. This allows for individual toggling of effects.
* The effects have been slightly tweaked to look better on particularly light / dark backgrounds, but this should generally improve the effect.

## Upgrading from 0.0.x

If you have customised your variants in the config, these will need splitting into the 4 new variants. Everything else should just work, though you may see some slight differences in colors on particularly light / dark backgrounds - hopefully you'll agree the tweaks are a modest improvement.